### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ mineassemble.%: src/%.ld $(OBJS)
 # Test in QEMU
 
 test: mineassemble.bin
-	qemu-system-i386 -kernel mineassemble.bin
+	qemu-system-i386 -enable-kvm -kernel mineassemble.bin
 
 .PHONY: test
 


### PR DESCRIPTION
Added `-enable-kvm`, makes game playable when running on Qemu guest

Note: Unsure if kvm support is available for most users, however [Qemu](https://www.archlinux.org/packages/extra/x86_64/qemu/) from the arch repo is compiled with support for kvm.